### PR TITLE
chore(deps): bump golang from 1.17.8-alpine to 1.20.2-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN yarn install --immutable
 RUN yarn build
 RUN yarn cache clean
 
-FROM golang:1.17.8-alpine AS go_builder
+FROM golang:1.20.2-alpine AS go_builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Bumps golang from 1.17.8-alpine to 1.20.2-alpine.

---
updated-dependencies:
- dependency-name: golang dependency-type: direct:production update-type: version-update:semver-minor ...